### PR TITLE
Add link to tutorials.yml

### DIFF
--- a/src/tutorial.yml
+++ b/src/tutorial.yml
@@ -1,3 +1,4 @@
+# Check out https://github.com/Multitallented/Civs/wiki/Tutorial-Config for more information on tutorials.
 default:
   steps:
   - type: build


### PR DESCRIPTION
Adds a wiki link to the tutorials.yml file so players can easily find out how to create their own tutorials.