### PR TITLE
Removal of Community item in main menu

### DIFF
--- a/Civs/menus/main.yml
+++ b/Civs/menus/main.yml
@@ -30,12 +30,6 @@
 #    name: regions
 #    actions:
 #      - menu:region-list
-#  community:
-#    index: 4
-#    icon: BOOKSHELF
-#    name: community
-#    actions:
-#      - menu:community
 #  towns:
 #    index: 9
 #    icon: RED_BED

--- a/src/main/java/resources/empty/menus/main.yml
+++ b/src/main/java/resources/empty/menus/main.yml
@@ -29,12 +29,6 @@ items:
     name: regions
     actions:
       - menu:region-list
-  community:
-    index: 4
-    icon: BOOKSHELF
-    name: community
-    actions:
-      - menu:community
   towns:
     index: 9
     icon: RED_BED


### PR DESCRIPTION
Removes the community menu item in the main menu due to the removal of community.yml.