### PR TITLE
fix compilation issues & add END tutorial type

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,6 +10,7 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <github.global.server>github</github.global.server>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
         </repository>
         <repository>
             <id>placeholderapi</id>
-            <url>http://repo.extendedclip.com/content/repositories/placeholderapi/</url>
+            <url>https://repo.extendedclip.com/content/repositories/placeholderapi/</url>
         </repository>
         <repository>
             <id>Scarsz-Nexus</id>
@@ -37,7 +37,7 @@
         </repository>
         <repository>
             <id>dynmap</id>
-            <url>http://repo.mikeprimm.com/</url>
+            <url>https://repo.mikeprimm.com/</url>
         </repository>
         <repository>
             <id>janmm14-public</id>

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
         </repository>
         <repository>
             <id>lumine</id>
-            <url>https://mvn.lumine.io/repository/maven-releases/</url>
+            <url>https://mvn.lumine.io/repository/maven-public/</url>
         </repository>
     </repositories>
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>org.redcastlemedia.multitallented</groupId>
     <artifactId>civs</artifactId>
-    <version>1.9.5</version>
+    <version>1.9.6-SNAPSHOT</version>
 
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>org.redcastlemedia.multitallented</groupId>
     <artifactId>civs</artifactId>
-    <version>1.9.6-SNAPSHOT</version>
+    <version>1.9.5</version>
 
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/src/main/java/org/redcastlemedia/multitallented/civs/tutorials/TutorialManager.java
+++ b/src/main/java/org/redcastlemedia/multitallented/civs/tutorials/TutorialManager.java
@@ -375,6 +375,7 @@ public class TutorialManager {
         KILL,
         BUY,
         MENU_ACTION,
-        CHOOSE
+        CHOOSE,
+        END
     }
 }

--- a/src/test/java/org/redcastlemedia/multitallented/civs/regions/RegionsTests.java
+++ b/src/test/java/org/redcastlemedia/multitallented/civs/regions/RegionsTests.java
@@ -842,7 +842,7 @@ public class RegionsTests extends TestUtil {
         } catch (SuccessException se) {
 
         }
-        assertEquals(412, town.getPower());
+        assertEquals(402, town.getPower());
     }
 
     @Test

--- a/src/test/java/org/redcastlemedia/multitallented/civs/regions/RegionsTests.java
+++ b/src/test/java/org/redcastlemedia/multitallented/civs/regions/RegionsTests.java
@@ -842,7 +842,7 @@ public class RegionsTests extends TestUtil {
         } catch (SuccessException se) {
 
         }
-        assertEquals(402, town.getPower());
+        assertEquals(412, town.getPower());
     }
 
     @Test


### PR DESCRIPTION
this PR addresses 3 issues:
- current pom.xml uses a private maven repository in the lumine nexus instance -- this switches it to the public maven group
- current pom.xml uses http for a few repositories -- this breaks on maven 3.8+, fixed by switching to https
- default tutorial.yml references a non-existent "end" tutorial type -- this adds that constant to the tutorial type enum

made these changes for @hypervx2, but figured i'd backport to upstream in case you found them useful! enjoy :)